### PR TITLE
Misused promises linting

### DIFF
--- a/client/src/pages/admin/SettingsPage.tsx
+++ b/client/src/pages/admin/SettingsPage.tsx
@@ -51,11 +51,10 @@ export function SettingsPage() {
 				setLoading(false);
 			}
 		}
-		load();
+		void load();
 	}, []);
 
-	async function handleSubmit(e: React.FormEvent) {
-		e.preventDefault();
+	async function submitSettings() {
 		setMessage(null);
 		setSaving(true);
 		try {
@@ -75,8 +74,12 @@ export function SettingsPage() {
 		}
 	}
 
-	async function handleImportSubmit(e: React.FormEvent) {
+	function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
+		void submitSettings();
+	}
+
+	async function importCalendar() {
 		if (!importFile) return;
 		setImportError(null);
 		setImportResult(null);
@@ -101,6 +104,11 @@ export function SettingsPage() {
 		} finally {
 			setImportLoading(false);
 		}
+	}
+
+	function handleImportSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		void importCalendar();
 	}
 
 	if (loading) return <div className="muted">Loading...</div>;


### PR DESCRIPTION
Fixes `@typescript-eslint/no-misused-promises` lint errors by ensuring React event handlers and Express route handlers correctly handle promises where a void return is expected.

The linter flagged `async` React `onSubmit` handlers and `async` Express route handlers because they implicitly return promises, but the contexts in which they were used expected a `void` return. For React, `void` expressions were used to explicitly discard the promise. For Express, a new `asyncHandler` utility was introduced to wrap `async` route functions, ensuring that Express receives a void-returning handler while still allowing for proper async error handling.

---
<p><a href="https://cursor.com/agents?id=bc-f30a93e5-82f1-4b2a-9a04-02baa955c9f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f30a93e5-82f1-4b2a-9a04-02baa955c9f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

